### PR TITLE
Fix: Middleware configuration ignored in Artisan page

### DIFF
--- a/src/Pages/Artisan.php
+++ b/src/Pages/Artisan.php
@@ -33,10 +33,7 @@ class Artisan extends Page implements HasTable, HasActions
 
     public static function getRouteMiddleware(Panel $panel): string|array
     {
-        $middlewares = [
-            'auth',
-            'verified',
-        ];
+        $middlewares = config('filament-artisan.middlewares', ['web', 'auth']);
 
         if (config('filament-artisan.developer_gate', true)) {
             $middlewares[] = DeveloperGateMiddleware::class;


### PR DESCRIPTION
# Fix: Middleware config ignored - dead configuration

## Problem
`getRouteMiddleware()` hardcodes middleware instead of reading from config:

```php
// Current broken code
$middlewares = [
    'auth',      // ❌ Hardcoded 
    'verified',  // ❌ Ignores config
];
```

This makes `config('filament-artisan.middlewares')` completely useless. Also, the default, hardcoded configuration crashes our system as we don't use `verified` middleware at all.

## Fix
One line change - read from config:

```diff
- $middlewares = ['auth', 'verified'];
+ $middlewares = config('filament-artisan.middlewares', ['web']);
```

## Impact
- ✅ Config now works as documented
- ✅ No breaking changes
- ✅ Enables proper access control

**Type:** Bug fix | **Risk:** Low

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated middleware handling for the Artisan page to use configurable settings, allowing for easier customization of route protection. No visible changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->