### PR TITLE
Make output more readable (font, aligns)

### DIFF
--- a/src/Pages/Artisan.php
+++ b/src/Pages/Artisan.php
@@ -69,13 +69,24 @@ class Artisan extends Page implements HasTable, HasActions
             Action::make('output')
                 ->icon('heroicon-s-computer-desktop')
                 ->color('warning')
-                ->form(fn(array $arguments = []) => [
-                    Textarea::make('output')
-                        ->autosize()
-                        ->default($arguments ? $arguments['output'] : session()->get('terminal_output'))
-                        ->disabled()
-                        ->label(trans('filament-artisan::messages.actions.output'))
-                ])
+                ->modalHeading('Command Output')
+                ->modalContent(function (array $arguments = []) {
+                    $output = $arguments ? $arguments['output'] : session()->get('terminal_output');
+
+                    return new HtmlString("
+                    <pre style='font-family: Monaco, Menlo, Ubuntu Mono, Consolas, Courier New, monospace; 
+                               font-size: 13px; 
+                               line-height: 1.4; 
+                               border: 1px solid #333;
+                               width: 100%;
+                               overflow-x: auto;
+                               white-space: pre;
+                               margin: 0;
+                               padding: 1rem;'>{$output}</pre>
+                ");
+                })
+                ->modalSubmitAction(false)
+                ->modalCancelActionLabel('Close')
                 ->label(trans('filament-artisan::messages.actions.output')),
         ];
 

--- a/src/Pages/Artisan.php
+++ b/src/Pages/Artisan.php
@@ -17,6 +17,7 @@ use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
 use Illuminate\Support\Facades\App;
+use Illuminate\Support\HtmlString;
 use Symfony\Component\Console\Output\BufferedOutput;
 use TomatoPHP\FilamentArtisan\Http\Controllers\GuiController;
 use TomatoPHP\FilamentArtisan\Models\Command;


### PR DESCRIPTION
Make output more readable.

![image](https://github.com/user-attachments/assets/7fc1394c-6285-4394-bdcf-c42a8ff406bf)

It would be great to handle better ASCII formatting (spacing, colours, etc.,) but I think it is a good starting point.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the command output modal to display results in a formatted, read-only view with improved styling and scrollable content.
- **User Interface**
  - The command output is now shown in a static modal with a "Close" button, making it easier to review results without editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->